### PR TITLE
Significant improvements in functionality and performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ pom.xml
 .lein-failures
 .lein-plugins
 .lein-repl-history
+.nrepl-port
 .classpath
 .project
-
+output.log

--- a/dev-resources/event_lookup_all.json
+++ b/dev-resources/event_lookup_all.json
@@ -1,0 +1,3 @@
+{"queries":
+  [{"ua":"Lenovo-A288t_TD/S100 Linux/2.6.35 Android/2.3.5 Release/02.29.2012 Browser/AppleWebkit533.1 Mobile Safari/533.1 FlyFlow/1.4",
+    "lookup":"useragent"}]}

--- a/dev-resources/event_lookup_browser.json
+++ b/dev-resources/event_lookup_browser.json
@@ -1,0 +1,3 @@
+{"queries":
+  [{"ua":"Lenovo-A288t_TD/S100 Linux/2.6.35 Android/2.3.5 Release/02.29.2012 Browser/AppleWebkit533.1 Mobile Safari/533.1 FlyFlow/1.4",
+    "lookup":"browser"}]}

--- a/dev-resources/event_lookup_device.json
+++ b/dev-resources/event_lookup_device.json
@@ -1,0 +1,3 @@
+{"queries":
+  [{"ua":"Lenovo-A288t_TD/S100 Linux/2.6.35 Android/2.3.5 Release/02.29.2012 Browser/AppleWebkit533.1 Mobile Safari/533.1 FlyFlow/1.4",
+    "lookup":"device"}]}

--- a/dev-resources/event_lookup_multiple.json
+++ b/dev-resources/event_lookup_multiple.json
@@ -1,0 +1,9 @@
+{"queries":
+  [{"ua":"Lenovo-A288t_TD/S100 Linux/2.6.35 Android/2.3.5 Release/02.29.2012 Browser/AppleWebkit533.1 Mobile Safari/533.1 FlyFlow/1.4",
+    "lookup":"useragent"},
+   {"ua":"Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.0.19) Gecko/2010031218 FreeBSD/i386 Firefox/3.0.19,gzip(gfe),gzip(gfe)",
+    "lookup":"browser"},
+   {"ua":"Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; Amaze_4G Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30",
+    "lookup":"device"},
+   {"ua":"UCWEB/2.0 (Linux; U; Adr 2.3.6; en-US; HUAWEI_Y210-0251) U2/1.0.0 UCBrowser/8.6.0.318 U2/1.0.0 Mobile",
+    "lookup":"os"}]}

--- a/dev-resources/event_lookup_os.json
+++ b/dev-resources/event_lookup_os.json
@@ -1,0 +1,3 @@
+{"queries":
+  [{"ua":"Lenovo-A288t_TD/S100 Linux/2.6.35 Android/2.3.5 Release/02.29.2012 Browser/AppleWebkit533.1 Mobile Safari/533.1 FlyFlow/1.4",
+    "lookup":"os"}]}

--- a/dev-resources/event_payload.json
+++ b/dev-resources/event_payload.json
@@ -1,1 +1,0 @@
-{"useragent":"Lenovo-A288t_TD/S100 Linux/2.6.35 Android/2.3.5 Release/02.29.2012 Browser/AppleWebkit533.1 Mobile Safari/533.1 FlyFlow/1.4"}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject uap-clj-lambda "0.2.0"
+(defproject uap-clj-lambda "1.0.0"
   :description "Amazon AWS Lambda function wrapper around uap-clj"
   :url "https://github.com/russellwhitaker/uap-clj-lambda"
   :license {:name "The MIT License (MIT)"
@@ -7,7 +7,8 @@
         :url "https://github.com/russellwhitaker/uap-clj-lambda"}
   :dependencies [[org.clojure/clojure   "1.8.0"]
                  [uap-clj               "1.3.1"]
-                 [org.clojure/data.json "0.2.6"]
+                 [cheshire              "5.6.3"]
+                 [com.taoensso/timbre   "4.8.0"]
                  [uswitch/lambada       "0.1.2"]]
   :profiles {:dev {:resource-paths ["dev-resources"]
                    :dependencies [[speclj "3.3.2"]]
@@ -17,4 +18,6 @@
                        :uberjar-exclusions
                          [#"dev_resources|^test$|test_resources|docs|\.md|LICENSE|META-INF"]}}
   :plugins [[speclj       "3.3.2"]
-            [lein-ancient "0.6.10"]])
+            [lein-ancient "0.6.10"]]
+  :aliases {"test"  ["do" ["clean"] ["spec" "--reporter=d"]]
+            "build" ["do" ["clean"] ["uberjar"]]})

--- a/spec/uap_clj_lambda/core_spec.clj
+++ b/spec/uap_clj_lambda/core_spec.clj
@@ -1,16 +1,87 @@
 (ns uap-clj-lambda.core-spec
   (:refer-clojure :exclude [read])
-  (:require [speclj.core :refer :all]
-            [clojure.data.json :as json :refer [read write]]
-            [clojure.java.io :as io :refer [reader writer]]
-            [uap-clj-lambda.core :refer [handle-event]]))
+  (:require [speclj.core :refer [context describe it should==]]
+            [clojure.java.io :as io :refer [reader]]
+            [cheshire.core :as json :refer [parse-stream]]
+            [uap-clj-lambda.core :refer [handle-event lookup]]))
 
-(def payload (json/read (io/reader "dev-resources/event_payload.json")))
-(def result {:ua "Lenovo-A288t_TD/S100 Linux/2.6.35 Android/2.3.5 Release/02.29.2012 Browser/AppleWebkit533.1 Mobile Safari/533.1 FlyFlow/1.4",
-             :browser {:family "Baidu Explorer", :major "1", :minor "4", :patch ""},
-             :os {:family "Android", :major "2", :minor "3", :patch "5", :patch_minor ""},
-             :device {:family "Lenovo A288t_TD", :brand "Lenovo", :model "A288t_TD"}})
+(def ua "Lenovo-A288t_TD/S100 Linux/2.6.35 Android/2.3.5 Release/02.29.2012 Browser/AppleWebkit533.1 Mobile Safari/533.1 FlyFlow/1.4")
 
-(describe "Event handler output"
-  (it "Looks up a useragent string and emits browser, device, and o/s information"
-    (should== result (handle-event payload))))
+(def full-req (json/parse-stream (io/reader "dev-resources/event_lookup_all.json") true))
+(def browser-req (json/parse-stream (io/reader "dev-resources/event_lookup_browser.json") true))
+(def device-req (json/parse-stream (io/reader "dev-resources/event_lookup_device.json") true))
+(def os-req (json/parse-stream (io/reader "dev-resources/event_lookup_os.json") true))
+(def multi-req (json/parse-stream (io/reader "dev-resources/event_lookup_multiple.json") true))
+
+(def full-result
+  {:results
+    [{:ua ua
+      :browser {:family "Baidu Explorer", :major "1", :minor "4", :patch ""}
+      :os {:family "Android", :major "2", :minor "3", :patch "5", :patch_minor ""}
+      :device {:family "Lenovo A288t_TD", :brand "Lenovo", :model "A288t_TD"}}]})
+
+(def browser-result
+  {:results
+    [{:ua ua
+      :browser {:family "Baidu Explorer", :major "1", :minor "4", :patch ""}}]})
+
+(def device-result
+  {:results
+    [{:ua ua
+      :device {:family "Lenovo A288t_TD", :brand "Lenovo", :model "A288t_TD"}}]})
+
+(def os-result
+  {:results
+    [{:ua ua
+      :os {:family "Android", :major "2", :minor "3", :patch "5", :patch_minor ""}}]})
+
+(def multi-result
+  {:results
+   [{:ua
+     "Lenovo-A288t_TD/S100 Linux/2.6.35 Android/2.3.5 Release/02.29.2012 Browser/AppleWebkit533.1 Mobile Safari/533.1 FlyFlow/1.4",
+     :browser
+     {:family "Baidu Explorer", :major "1", :minor "4", :patch ""},
+     :os
+     {:family "Android",
+      :major "2",
+      :minor "3",
+      :patch "5",
+      :patch_minor ""},
+     :device
+     {:family "Lenovo A288t_TD", :brand "Lenovo", :model "A288t_TD"}}
+    {:browser {:family "Firefox", :major "3", :minor "0", :patch "19"},
+     :ua
+     "Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.0.19) Gecko/2010031218 FreeBSD/i386 Firefox/3.0.19,gzip(gfe),gzip(gfe)"}
+    {:device {:family "HTC Amaze 4G", :brand "HTC", :model "Amaze 4G"},
+     :ua
+     "Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; Amaze_4G Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30"}
+    {:os
+     {:family "Android",
+      :major "2",
+      :minor "3",
+      :patch "6",
+      :patch_minor ""},
+     :ua
+     "UCWEB/2.0 (Linux; U; Adr 2.3.6; en-US; HUAWEI_Y210-0251) U2/1.0.0 UCBrowser/8.6.0.318 U2/1.0.0 Mobile"}]})
+
+(context "event handling"
+  (describe "single full lookup"
+    (it "takes a useragent string and returns browser, device, and o/s fields"
+      (should== full-result
+                (handle-event full-req))))
+  (describe "single browser lookup"
+    (it "takes a useragent string and returns browser fields"
+      (should== browser-result
+                (handle-event browser-req))))
+  (describe "single device lookup"
+    (it "takes a useragent string and returns device fields"
+      (should== device-result
+                (handle-event device-req))))
+  (describe "single o/s lookup"
+    (it "takes a useragent string and returns o/s fields"
+      (should== os-result
+                (handle-event os-req))))
+  (describe "multiple mixed lookup"
+    (it "handles multiple mixed queries in one payload"
+      (should== multi-result
+                (handle-event multi-req)))))

--- a/src/uap_clj_lambda/core.clj
+++ b/src/uap_clj_lambda/core.clj
@@ -1,17 +1,39 @@
 (ns uap-clj-lambda.core
   (:refer-clojure :exclude [read])
   (:require [uswitch.lambada.core :refer [deflambdafn]]
-            [clojure.data.json :as json :refer [read write]]
+            [cheshire.core :as json :refer [generate-string
+                                            parse-stream]]
             [clojure.java.io :as io :refer [reader writer]]
-            [uap-clj.core :refer [useragent]]))
+            [taoensso.timbre :as log :refer [info]]
+            [uap-clj.core :refer [useragent]]
+            [uap-clj.browser :refer [browser]]
+            [uap-clj.device :refer [device]]
+            [uap-clj.os :refer [os]]))
+
+(defn lookup
+  "Look up full useragent fields, or only lookup device,
+   o/s, or browser fields.
+  "
+  [query]
+  (let [{:keys [ua lookup]} query
+        parser (if (= "useragent" lookup)
+                 (symbol "uap-clj.core/useragent")
+                 (symbol (str "uap-clj." lookup) lookup))]
+    (if (= "useragent" lookup)
+      ((resolve parser) ua)
+      (merge {(keyword lookup) ((resolve parser) ua)}
+             {:ua ua}))))
 
 (defn handle-event
+  "Get request and look up against all useragents therein
+  "
   [event]
-  (useragent (get-in event ["useragent"])))
+  {:results (into [] (map lookup (:queries event)))})
 
-(deflambdafn uap-clj-lambda.core.SimpleUseragentLookup
+(deflambdafn uap-clj-lambda.core.UseragentLookup
   [in out _]
-  (let [event (json/read (io/reader in))
+  (let [event (json/parse-stream (io/reader in) true)
         result (handle-event event)]
+    (log/info result)
     (with-open [wtr (io/writer out)]
-      (json/write result wtr))))
+      (.write wtr (json/generate-string result)))))


### PR DESCRIPTION
- replaced clojure.data.json lib with Cheshire
- expanded lookup to return o/s, device, browser, or all field types
- expanded lookup to allow batching of multiple useragent strings, each on any of the above lookup types
- added INFO level logging to CloudWatch